### PR TITLE
respect existing VIRTUALENVWRAPPER_PYTHON

### DIFF
--- a/bin/pyenv-virtualenvwrapper
+++ b/bin/pyenv-virtualenvwrapper
@@ -66,7 +66,9 @@ lib() {
         }
       }
 
-      export VIRTUALENVWRAPPER_PYTHON="${prefix}/bin/python"
+      # if the python version used by virtualenvwrapper is already set, respect
+      # it
+      [ -x "${VIRTUALENVWRAPPER_PYTHON}" ] || export VIRTUALENVWRAPPER_PYTHON="${prefix}/bin/python"
       [ -x "${VIRTUALENVWRAPPER_PYTHON}" ] || {
         export VIRTUALENVWRAPPER_PYTHON="$(pyenv which python 2>/dev/null || true)"
         [ -x "${VIRTUALENVWRAPPER_PYTHON}" ] || {


### PR DESCRIPTION
With this commit, ``VIRTUALENVWRAPPER_PYTHON`` is not set to ``{prefix}/bin/python`` if it is already present in the environment. I installed virtualenvwrapper under python3 long ago and with the current change I can run ``pyenv virtualenvwrapper`` without errors.